### PR TITLE
Handle multihost support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "url.h"]
+	path = url.h
+	url = https://github.com/jwerle/url.h.git

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PREFIX ?= /usr/local
 
 make:
-	gcc -std=c99 -Wall -o zpm -g zpm.c
+	gcc -std=gnu99 -Wall -o zpm -g zpm.c
 
 test:
 	tests/setup.sh

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PREFIX ?= /usr/local
 
 make:
-	gcc -Wall -o zpm -g zpm.c
+	gcc -std=c99 -Wall -o zpm -g zpm.c
 
 test:
 	tests/setup.sh

--- a/tests/disable.t
+++ b/tests/disable.t
@@ -20,6 +20,6 @@ Plugin can be properly enabled/installed after "disable"
   $ zpm disable "$ZPM_TEST_REPOS/example-plugin" > /dev/null
   $ zpm "$ZPM_TEST_REPOS/example-plugin" > /dev/null
   $ zpm list
-  .*example-plugin .* (re)
+  .*example-plugin@.* (re)
 
 

--- a/tests/list.t
+++ b/tests/list.t
@@ -35,8 +35,8 @@ Subsequentially add a new item to the list.
 List command show list of installed plugins.
 
   $ zpm list
-  .*example-plugin .* (re)
-  .*example-theme .* (re)
+  .*example-plugin@.* (re)
+  .*example-theme@.* (re)
 
 Do not allow duplicate plugin entries/items.
 
@@ -45,6 +45,6 @@ Do not allow duplicate plugin entries/items.
   $ zpm "$ZPM_TEST_REPOS/example-theme" > /dev/null
   [1]
   $ zpm list
-  .*example-theme .* (re)
+  .*example-theme@.* (re)
 
 

--- a/tests/remove.t
+++ b/tests/remove.t
@@ -17,7 +17,7 @@ Plugin parent directory is not removed if not empty
 Plugin directory is properly unlinked after remove and parent directory is properly removed
 
   $ zpm list
-  zsh-users/zsh-autosuggestions .* (re)
+  zsh-users/zsh-autosuggestions@.* (re)
 
   $ zpm "zsh-users/zsh-syntax-highlighting" > /dev/null
   $ zpm remove "zsh-users/zsh-syntax-highlighting" > /dev/null

--- a/zpm.c
+++ b/zpm.c
@@ -10,6 +10,8 @@
 #include <dirent.h>
 #include <sys/stat.h>
 
+#include "url.h/url.h"
+
 #define TRUE 1
 #define FALSE 0
 
@@ -24,11 +26,13 @@ char* generate_plugin_path(char* plugin_name) {
     char* plugin_path = malloc(PATH_MAX);
     strcpy(plugin_path, getenv("HOME"));
     strcat(plugin_path, "/.zpm/plugins/");
-    if (strncmp(plugin_name, "github.com/", 11)) {
+    url_data_t *parsed = url_parse(plugin_name);
+    if (NULL == parsed) {
         strcat(plugin_path, plugin_name);
     } else {
-        strcat(plugin_path, plugin_name + 11);
+        strcat(plugin_path, parsed->path);
     }
+
     return plugin_path;
 }
 
@@ -131,11 +135,12 @@ int plugin_list_add_item(char* plugin_name) {
     if (!store) {
         return -1;
     }
-
-    if (!strncmp(plugin_name, "github.com", 11)) {
-        strcpy(plugin_item, plugin_name + 11);
-    } else {
+    url_data_t *parsed = url_parse(plugin_name);
+    if (NULL == parsed) {
         strcpy(plugin_item, plugin_name);
+    } else {
+        strcpy(plugin_item, parsed->host);
+        strcat(plugin_item, parsed->path);
     }
     strcat(plugin_item, "\n");
 
@@ -256,13 +261,14 @@ char* generate_repository_url(char* plugin_name) {
       return NULL;
       free(url);
     }
-    tmp = strstr(tmp + 1, "/");
-    if (!tmp) { 
+    url_data_t *parsed = url_parse(plugin_name);
+    if (NULL == parsed) {
         strcpy(url, "https://github.com/");
+        strcat(url, plugin_name);
     } else {
-        strcpy(url, "https://");
+        strcpy(url, plugin_name);
     }
-    strcat(url, plugin_name);
+ 
 
     return url;
 }
@@ -324,7 +330,7 @@ int plugins_update_local_clone() {
       printf("Nothing to update.");
       return 1;
     }
-    printf("Updating plugins ...\n");
+    printf("Updating plugins...\n");
     while (plugin_name) {
         if (plugin_name[0] == '/') {
             plugin_name = strtok(NULL, "\n");
@@ -391,7 +397,7 @@ int plugin_print_list() {
        char* hash = plugin_get_hash(plugin_name);
        printf("%s", plugin_name);
        if (hash) {
-           printf(" %s", hash);
+           printf("@%s", hash);
            free(hash);
        } else {
           printf("\n");


### PR DESCRIPTION
- Add [url.h](https://github.com/jwerle/url.h) module
- Quick hack to handle managing urls

- Changed output `list` command to use `@` to separate plugin name from hash. (should probably better done in another PR).